### PR TITLE
fix: add required modifier to Title and UpdateTodoCommandValidatorTests

### DIFF
--- a/Domain/Todos/Todo.cs
+++ b/Domain/Todos/Todo.cs
@@ -2,6 +2,6 @@ namespace Domain.Todos;
 public class Todo
 {
     public Guid Id { get; set; }
-    public string Title { get; set; }
+    public required string Title { get; set; }
     public bool Completed { get; set; }
 }

--- a/Tests/Todos/Validators/UpdateTodoCommandValidatorTests.cs
+++ b/Tests/Todos/Validators/UpdateTodoCommandValidatorTests.cs
@@ -1,0 +1,24 @@
+using Application.Todos.Command.UpdateTodo;
+using Application.Todos.Command.UpdateToDo;
+
+namespace Tests.Todos.Validators;
+
+public class UpdateTodoCommandValidatorTests
+{
+    private readonly UpdateTodoCommandValidator _validator = new();
+
+    [Fact]
+    public void Validate_Passes_WhenTitleIsNotEmpty()
+    {
+        var result = _validator.Validate(new UpdateToDoCommand(Guid.NewGuid(), "Valid Title", false));
+        Assert.True(result.IsValid);
+    }
+
+    [Fact]
+    public void Validate_Fails_WhenTitleIsEmpty()
+    {
+        var result = _validator.Validate(new UpdateToDoCommand(Guid.NewGuid(), string.Empty, false));
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Errors, e => e.ErrorMessage == "Title should not be empty");
+    }
+}


### PR DESCRIPTION
Fixes CS8618 warning on Todo.Title property by adding required modifier. Adds missing UpdateTodoCommandValidatorTests.

Resolves #4

Generated with [Claude Code](https://claude.ai/code)